### PR TITLE
Modify delete command to take in multiple inputs

### DIFF
--- a/src/main/java/seedu/address/commons/core/index/Index.java
+++ b/src/main/java/seedu/address/commons/core/index/Index.java
@@ -1,5 +1,7 @@
 package seedu.address.commons.core.index;
 
+import java.util.Objects;
+
 /**
  * Represents a zero-based or one-based index.
  *
@@ -51,4 +53,10 @@ public class Index {
                 || (other instanceof Index // instanceof handles nulls
                 && zeroBasedIndex == ((Index) other).zeroBasedIndex); // state check
     }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(zeroBasedIndex);
+    }
+
 }

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -3,6 +3,7 @@ package seedu.address.logic.commands;
 import static java.util.Objects.requireNonNull;
 
 import java.util.List;
+import java.util.Set;
 
 import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.index.Index;
@@ -11,7 +12,7 @@ import seedu.address.model.Model;
 import seedu.address.model.person.Person;
 
 /**
- * Deletes a person identified using it's displayed index from the address book.
+ * Deletes one or more persons identified using it's displayed index from the address book.
  */
 public class DeleteCommand extends Command {
 
@@ -22,32 +23,35 @@ public class DeleteCommand extends Command {
             + "Parameters: INDEX (must be a positive integer)\n"
             + "Example: " + COMMAND_WORD + " 1";
 
-    public static final String MESSAGE_DELETE_PERSON_SUCCESS = "Deleted Person: %1$s";
+    public static final String MESSAGE_DELETE_PERSON_SUCCESS = "Deleted Person(s):\n";
+    public static final String MESSAGE_FORMAT_SPECIFIER = "%1$s";
 
-    private final Index targetIndex;
+    public final Set<Index> targetIndexSet;
 
-    public DeleteCommand(Index targetIndex) {
-        this.targetIndex = targetIndex;
+    public DeleteCommand(Set<Index> targetIndexSet) {
+        this.targetIndexSet = targetIndexSet;
     }
 
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
         List<Person> lastShownList = model.getFilteredPersonList();
-
-        if (targetIndex.getZeroBased() >= lastShownList.size()) {
-            throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        String deleteMessage = MESSAGE_DELETE_PERSON_SUCCESS;
+        for (Index targetIndex : targetIndexSet) {
+            if (targetIndex.getZeroBased() >= lastShownList.size()) {
+                throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+            }
+            Person personToDelete = lastShownList.get(targetIndex.getZeroBased());
+            model.deletePerson(personToDelete);
+            deleteMessage += personToDelete + "\n";
         }
-
-        Person personToDelete = lastShownList.get(targetIndex.getZeroBased());
-        model.deletePerson(personToDelete);
-        return new CommandResult(String.format(MESSAGE_DELETE_PERSON_SUCCESS, personToDelete));
+        return new CommandResult(deleteMessage);
     }
 
     @Override
     public boolean equals(Object other) {
         return other == this // short circuit if same object
                 || (other instanceof DeleteCommand // instanceof handles nulls
-                && targetIndex.equals(((DeleteCommand) other).targetIndex)); // state check
+                && this.targetIndexSet.equals(((DeleteCommand) other).targetIndexSet)); // state check
     }
 }

--- a/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
@@ -20,7 +20,7 @@ public class DeleteCommandParser implements Parser<DeleteCommand> {
 
     /**
      * Parses the given {@code String} of arguments in the context of the DeleteCommand
-     * and returns a DeleteCommand object for each index in the arguments for execution.
+     * and returns a DeleteCommand object that contains each index in the arguments for execution.
      * @throws ParseException if the user input does not conform the expected format
      */
     public DeleteCommand parse(String args) throws ParseException {

--- a/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
@@ -6,6 +6,8 @@ import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
+import java.util.*;
+
 /**
  * Parses input arguments and creates a new DeleteCommand object
  */
@@ -13,13 +15,16 @@ public class DeleteCommandParser implements Parser<DeleteCommand> {
 
     /**
      * Parses the given {@code String} of arguments in the context of the DeleteCommand
-     * and returns a DeleteCommand object for execution.
+     * and returns a DeleteCommand object for each index in the arguments for execution.
      * @throws ParseException if the user input does not conform the expected format
      */
     public DeleteCommand parse(String args) throws ParseException {
         try {
-            Index index = ParserUtil.parseIndex(args);
-            return new DeleteCommand(index);
+            String trimmedArgs = args.trim();
+            List<String> stringOfIndexesList = Arrays.asList(trimmedArgs.split("\\s+"));
+            Collections.sort(stringOfIndexesList, Collections.reverseOrder());
+            Set<Index> indexSet = ParserUtil.parseIndexes(stringOfIndexesList);
+            return new DeleteCommand(indexSet);
         } catch (ParseException pe) {
             throw new ParseException(
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE), pe);

--- a/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
@@ -2,11 +2,16 @@ package seedu.address.logic.parser;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
-import java.util.*;
+
 
 /**
  * Parses input arguments and creates a new DeleteCommand object

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -41,7 +41,7 @@ public class ParserUtil {
     /**
      * Parses {@code Collection<String> oneBasedIndexes} into a {@code Set<Index>}
      */
-    public static Set<Index> parseIndexes (Collection<String> oneBasedIndexes) throws ParseException {
+    public static Set<Index> parseIndexes(Collection<String> oneBasedIndexes) throws ParseException {
         requireNonNull(oneBasedIndexes);
         final Set<Index> indexSet = new LinkedHashSet<>();
         for (String oneBasedIndex : oneBasedIndexes) {

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -4,6 +4,7 @@ import static java.util.Objects.requireNonNull;
 
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Set;
 
 import seedu.address.commons.core.index.Index;
@@ -35,6 +36,18 @@ public class ParserUtil {
             throw new ParseException(MESSAGE_INVALID_INDEX);
         }
         return Index.fromOneBased(Integer.parseInt(trimmedIndex));
+    }
+
+    /**
+     * Parses {@code Collection<String> oneBasedIndexes} into a {@code Set<Index>}
+     */
+    public static Set<Index> parseIndexes (Collection<String> oneBasedIndexes) throws ParseException {
+        requireNonNull(oneBasedIndexes);
+        final Set<Index> indexSet = new LinkedHashSet<>();
+        for (String oneBasedIndex : oneBasedIndexes) {
+            indexSet.add(parseIndex(oneBasedIndex));
+        }
+        return indexSet;
     }
 
     /**

--- a/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
@@ -8,8 +8,8 @@ import static seedu.address.logic.commands.CommandTestUtil.showPersonAtIndex;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
-import static seedu.address.testutil.TypicalSetsOfIndex.SET_OF_ONE_INDEX;
 import static seedu.address.testutil.TypicalSetsOfIndex.SET_OF_ONE_AND_SECOND_INDEX;
+import static seedu.address.testutil.TypicalSetsOfIndex.SET_OF_ONE_INDEX;
 import static seedu.address.testutil.TypicalSetsOfIndex.SET_OF_SECOND_INDEX;
 
 import java.util.Arrays;

--- a/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
@@ -1,5 +1,8 @@
 package seedu.address.logic.commands;
 
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
@@ -19,9 +22,6 @@ import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
 import seedu.address.model.person.Person;
-
-import java.util.Arrays;
-import java.util.LinkedHashSet;
 
 /**
  * Contains integration tests (interaction with the Model) and unit tests for

--- a/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
@@ -8,7 +8,10 @@ import static seedu.address.logic.commands.CommandTestUtil.showPersonAtIndex;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
-import static seedu.address.testutil.TypicalSetsOfIndex.*;
+import static seedu.address.testutil.TypicalSetsOfIndex.SET_OF_ONE_INDEX;
+import static seedu.address.testutil.TypicalSetsOfIndex.SET_OF_SECOND_INDEX;
+import static seedu.address.testutil.TypicalSetsOfIndex.SET_OF_ONE_AND_SECOND_INDEX;
+
 
 import java.util.Arrays;
 import java.util.LinkedHashSet;
@@ -68,7 +71,7 @@ public class DeleteCommandTest {
     }
 
     @Test
-    public void execute_MultipleValidWithOneInvalidIndexUnfilteredList_throwsCommandException() {
+    public void execute_multipleValidWithOneInvalidIndexUnfilteredList_throwsCommandException() {
         Index outOfBoundIndex = Index.fromOneBased(model.getFilteredPersonList().size() + 1);
         DeleteCommand deleteCommand = new DeleteCommand(new LinkedHashSet<Index>(
                 Arrays.asList(outOfBoundIndex, INDEX_SECOND_PERSON, INDEX_FIRST_PERSON)));

--- a/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
@@ -9,9 +9,8 @@ import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 import static seedu.address.testutil.TypicalSetsOfIndex.SET_OF_ONE_INDEX;
-import static seedu.address.testutil.TypicalSetsOfIndex.SET_OF_SECOND_INDEX;
 import static seedu.address.testutil.TypicalSetsOfIndex.SET_OF_ONE_AND_SECOND_INDEX;
-
+import static seedu.address.testutil.TypicalSetsOfIndex.SET_OF_SECOND_INDEX;
 
 import java.util.Arrays;
 import java.util.LinkedHashSet;

--- a/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
@@ -8,6 +8,8 @@ import static seedu.address.logic.commands.CommandTestUtil.showPersonAtIndex;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+import static seedu.address.testutil.TypicalSetsOfIndex.SET_OF_ONE_INDEX;
+import static seedu.address.testutil.TypicalSetsOfIndex.SET_OF_SECOND_INDEX;
 
 import org.junit.jupiter.api.Test;
 
@@ -17,6 +19,9 @@ import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
 import seedu.address.model.person.Person;
+
+import java.util.Arrays;
+import java.util.LinkedHashSet;
 
 /**
  * Contains integration tests (interaction with the Model) and unit tests for
@@ -29,9 +34,9 @@ public class DeleteCommandTest {
     @Test
     public void execute_validIndexUnfilteredList_success() {
         Person personToDelete = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
-        DeleteCommand deleteCommand = new DeleteCommand(INDEX_FIRST_PERSON);
+        DeleteCommand deleteCommand = new DeleteCommand(SET_OF_ONE_INDEX);
 
-        String expectedMessage = String.format(DeleteCommand.MESSAGE_DELETE_PERSON_SUCCESS, personToDelete);
+        String expectedMessage = DeleteCommand.MESSAGE_DELETE_PERSON_SUCCESS + personToDelete + "\n";
 
         ModelManager expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
         expectedModel.deletePerson(personToDelete);
@@ -42,7 +47,7 @@ public class DeleteCommandTest {
     @Test
     public void execute_invalidIndexUnfilteredList_throwsCommandException() {
         Index outOfBoundIndex = Index.fromOneBased(model.getFilteredPersonList().size() + 1);
-        DeleteCommand deleteCommand = new DeleteCommand(outOfBoundIndex);
+        DeleteCommand deleteCommand = new DeleteCommand(new LinkedHashSet<Index>(Arrays.asList(outOfBoundIndex)));
 
         assertCommandFailure(deleteCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
     }
@@ -52,9 +57,9 @@ public class DeleteCommandTest {
         showPersonAtIndex(model, INDEX_FIRST_PERSON);
 
         Person personToDelete = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
-        DeleteCommand deleteCommand = new DeleteCommand(INDEX_FIRST_PERSON);
+        DeleteCommand deleteCommand = new DeleteCommand(SET_OF_ONE_INDEX);
 
-        String expectedMessage = String.format(DeleteCommand.MESSAGE_DELETE_PERSON_SUCCESS, personToDelete);
+        String expectedMessage = DeleteCommand.MESSAGE_DELETE_PERSON_SUCCESS + personToDelete + "\n";
 
         Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
         expectedModel.deletePerson(personToDelete);
@@ -71,21 +76,21 @@ public class DeleteCommandTest {
         // ensures that outOfBoundIndex is still in bounds of address book list
         assertTrue(outOfBoundIndex.getZeroBased() < model.getAddressBook().getPersonList().size());
 
-        DeleteCommand deleteCommand = new DeleteCommand(outOfBoundIndex);
+        DeleteCommand deleteCommand = new DeleteCommand(new LinkedHashSet<Index>(Arrays.asList(outOfBoundIndex)));
 
         assertCommandFailure(deleteCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
     }
 
     @Test
     public void equals() {
-        DeleteCommand deleteFirstCommand = new DeleteCommand(INDEX_FIRST_PERSON);
-        DeleteCommand deleteSecondCommand = new DeleteCommand(INDEX_SECOND_PERSON);
+        DeleteCommand deleteFirstCommand = new DeleteCommand(SET_OF_ONE_INDEX);
+        DeleteCommand deleteSecondCommand = new DeleteCommand(SET_OF_SECOND_INDEX);
 
         // same object -> returns true
         assertTrue(deleteFirstCommand.equals(deleteFirstCommand));
 
         // same values -> returns true
-        DeleteCommand deleteFirstCommandCopy = new DeleteCommand(INDEX_FIRST_PERSON);
+        DeleteCommand deleteFirstCommandCopy = new DeleteCommand(SET_OF_ONE_INDEX);
         assertTrue(deleteFirstCommand.equals(deleteFirstCommandCopy));
 
         // different types -> returns false

--- a/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
@@ -1,8 +1,5 @@
 package seedu.address.logic.commands;
 
-import java.util.Arrays;
-import java.util.LinkedHashSet;
-
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
@@ -13,6 +10,9 @@ import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 import static seedu.address.testutil.TypicalSetsOfIndex.SET_OF_ONE_INDEX;
 import static seedu.address.testutil.TypicalSetsOfIndex.SET_OF_SECOND_INDEX;
+
+import java.util.Arrays;
+import java.util.LinkedHashSet;
 
 import org.junit.jupiter.api.Test;
 

--- a/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
@@ -8,8 +8,7 @@ import static seedu.address.logic.commands.CommandTestUtil.showPersonAtIndex;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
-import static seedu.address.testutil.TypicalSetsOfIndex.SET_OF_ONE_INDEX;
-import static seedu.address.testutil.TypicalSetsOfIndex.SET_OF_SECOND_INDEX;
+import static seedu.address.testutil.TypicalSetsOfIndex.*;
 
 import java.util.Arrays;
 import java.util.LinkedHashSet;
@@ -45,9 +44,34 @@ public class DeleteCommandTest {
     }
 
     @Test
+    public void execute_multipleValidIndexUnfilteredList_success() {
+        Person personToDelete1 = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        Person personToDelete2 = model.getFilteredPersonList().get(INDEX_SECOND_PERSON.getZeroBased());
+        DeleteCommand deleteCommand = new DeleteCommand(SET_OF_ONE_AND_SECOND_INDEX);
+
+        String expectedMessage = DeleteCommand.MESSAGE_DELETE_PERSON_SUCCESS + personToDelete2 + "\n"
+                + personToDelete1 + "\n";
+
+        ModelManager expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+        expectedModel.deletePerson(personToDelete2);
+        expectedModel.deletePerson(personToDelete1);
+
+        assertCommandSuccess(deleteCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
     public void execute_invalidIndexUnfilteredList_throwsCommandException() {
         Index outOfBoundIndex = Index.fromOneBased(model.getFilteredPersonList().size() + 1);
         DeleteCommand deleteCommand = new DeleteCommand(new LinkedHashSet<Index>(Arrays.asList(outOfBoundIndex)));
+
+        assertCommandFailure(deleteCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void execute_MultipleValidWithOneInvalidIndexUnfilteredList_throwsCommandException() {
+        Index outOfBoundIndex = Index.fromOneBased(model.getFilteredPersonList().size() + 1);
+        DeleteCommand deleteCommand = new DeleteCommand(new LinkedHashSet<Index>(
+                Arrays.asList(outOfBoundIndex, INDEX_SECOND_PERSON, INDEX_FIRST_PERSON)));
 
         assertCommandFailure(deleteCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
     }
@@ -80,6 +104,8 @@ public class DeleteCommandTest {
 
         assertCommandFailure(deleteCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
     }
+
+
 
     @Test
     public void equals() {

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -6,13 +6,16 @@ import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT
 import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+import static seedu.address.testutil.TypicalSetsOfIndex.SET_OF_ONE_INDEX;
 
 import java.util.Arrays;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.Test;
 
+import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.commands.EditCommand;
@@ -64,7 +67,8 @@ public class AddressBookParserTest {
     public void parseCommand_delete() throws Exception {
         DeleteCommand command = (DeleteCommand) parser.parseCommand(
             DeleteCommand.COMMAND_WORD + " " + INDEX_FIRST_PERSON.getOneBased());
-        assertEquals(new DeleteCommand(INDEX_FIRST_PERSON), command);
+        assertEquals(new DeleteCommand(SET_OF_ONE_INDEX).targetIndexSet, command.targetIndexSet);
+        Index test = Index.fromOneBased(1);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -9,7 +9,6 @@ import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 import static seedu.address.testutil.TypicalSetsOfIndex.SET_OF_ONE_INDEX;
 
 import java.util.Arrays;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.stream.Collectors;
 

--- a/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
@@ -3,7 +3,9 @@ package seedu.address.logic.parser;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
-import static seedu.address.testutil.TypicalSetsOfIndex.*;
+import static seedu.address.testutil.TypicalSetsOfIndex.SET_OF_ONE_INDEX;
+import static seedu.address.testutil.TypicalSetsOfIndex.SET_OF_SECOND_INDEX;
+import static seedu.address.testutil.TypicalSetsOfIndex.SET_OF_ONE_AND_SECOND_INDEX;
 
 import org.junit.jupiter.api.Test;
 

--- a/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
@@ -3,8 +3,8 @@ package seedu.address.logic.parser;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
-import static seedu.address.testutil.TypicalSetsOfIndex.SET_OF_ONE_INDEX;
 import static seedu.address.testutil.TypicalSetsOfIndex.SET_OF_ONE_AND_SECOND_INDEX;
+import static seedu.address.testutil.TypicalSetsOfIndex.SET_OF_ONE_INDEX;
 import static seedu.address.testutil.TypicalSetsOfIndex.SET_OF_SECOND_INDEX;
 
 import org.junit.jupiter.api.Test;

--- a/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
@@ -4,8 +4,8 @@ import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 import static seedu.address.testutil.TypicalSetsOfIndex.SET_OF_ONE_INDEX;
-import static seedu.address.testutil.TypicalSetsOfIndex.SET_OF_SECOND_INDEX;
 import static seedu.address.testutil.TypicalSetsOfIndex.SET_OF_ONE_AND_SECOND_INDEX;
+import static seedu.address.testutil.TypicalSetsOfIndex.SET_OF_SECOND_INDEX;
 
 import org.junit.jupiter.api.Test;
 

--- a/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
@@ -3,7 +3,7 @@ package seedu.address.logic.parser;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
-import static seedu.address.testutil.TypicalSetsOfIndex.SET_OF_ONE_INDEX;
+import static seedu.address.testutil.TypicalSetsOfIndex.*;
 
 import org.junit.jupiter.api.Test;
 
@@ -26,7 +26,22 @@ public class DeleteCommandParserTest {
     }
 
     @Test
+    public void parse_multipleValidArgs_returnsDeleteCommand() {
+        assertParseSuccess(parser, "1 2", new DeleteCommand(SET_OF_ONE_AND_SECOND_INDEX));
+    }
+
+    @Test
+    public void parse_multipleDuplicateValidArgs_returnsDeleteCommand() {
+        assertParseSuccess(parser, "2 2", new DeleteCommand(SET_OF_SECOND_INDEX));
+    }
+
+    @Test
     public void parse_invalidArgs_throwsParseException() {
         assertParseFailure(parser, "a", String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_invalidArgAmongValidArgs_throwsParseException() {
+        assertParseFailure(parser, "1 2 a", String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
     }
 }

--- a/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
@@ -3,7 +3,7 @@ package seedu.address.logic.parser;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
-import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+import static seedu.address.testutil.TypicalSetsOfIndex.SET_OF_ONE_INDEX;
 
 import org.junit.jupiter.api.Test;
 
@@ -22,7 +22,7 @@ public class DeleteCommandParserTest {
 
     @Test
     public void parse_validArgs_returnsDeleteCommand() {
-        assertParseSuccess(parser, "1", new DeleteCommand(INDEX_FIRST_PERSON));
+        assertParseSuccess(parser, "1", new DeleteCommand(SET_OF_ONE_INDEX));
     }
 
     @Test

--- a/src/test/java/seedu/address/testutil/TypicalSetsOfIndex.java
+++ b/src/test/java/seedu/address/testutil/TypicalSetsOfIndex.java
@@ -1,0 +1,19 @@
+package seedu.address.testutil;
+
+import seedu.address.commons.core.index.Index;
+
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
+
+/**
+ * A utility class containing a list of {@code Set<Index>} objects to be used in tests.
+ */
+public class TypicalSetsOfIndex {
+
+    public static final Set<Index> SET_OF_ONE_INDEX = new LinkedHashSet<>(Arrays.asList(INDEX_FIRST_PERSON));
+    public static final Set<Index> SET_OF_SECOND_INDEX = new LinkedHashSet<>(Arrays.asList(INDEX_SECOND_PERSON));
+}

--- a/src/test/java/seedu/address/testutil/TypicalSetsOfIndex.java
+++ b/src/test/java/seedu/address/testutil/TypicalSetsOfIndex.java
@@ -1,13 +1,13 @@
 package seedu.address.testutil;
 
-import seedu.address.commons.core.index.Index;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
 
 import java.util.Arrays;
 import java.util.LinkedHashSet;
 import java.util.Set;
 
-import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
-import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
+import seedu.address.commons.core.index.Index;
 
 /**
  * A utility class containing a list of {@code Set<Index>} objects to be used in tests.

--- a/src/test/java/seedu/address/testutil/TypicalSetsOfIndex.java
+++ b/src/test/java/seedu/address/testutil/TypicalSetsOfIndex.java
@@ -16,4 +16,6 @@ public class TypicalSetsOfIndex {
 
     public static final Set<Index> SET_OF_ONE_INDEX = new LinkedHashSet<>(Arrays.asList(INDEX_FIRST_PERSON));
     public static final Set<Index> SET_OF_SECOND_INDEX = new LinkedHashSet<>(Arrays.asList(INDEX_SECOND_PERSON));
+    public static final Set<Index> SET_OF_ONE_AND_SECOND_INDEX =
+            new LinkedHashSet<>(Arrays.asList(INDEX_SECOND_PERSON, INDEX_FIRST_PERSON));
 }


### PR DESCRIPTION
Fixes #40 

Delete Command takes in only one input.

User has to call delete command multiple times to delete more than one contact.

Allowing users to delete multiple contacts at once speeds up the process and makes it more convenient to manage the address book.

Let's modify delete command to take in multiple inputs by use of a LinkedHashSet of indexes.

