### PR TITLE
Differentiate between professor, TA and student

### DIFF
--- a/src/main/java/seedu/address/ui/PersonCard.java
+++ b/src/main/java/seedu/address/ui/PersonCard.java
@@ -57,7 +57,7 @@ public class PersonCard extends UiPart<Region> {
     public PersonCard(Person person, int displayedIndex) {
         super(FXML);
         this.person = person;
-        number.setText(displayedIndex + ". ");
+        id.setText(displayedIndex + ". ");
         name.setText(person.getName().fullName);
         phone.setText(person.getPhone().value);
         gender.setImage(getGenderImage(person));
@@ -69,7 +69,7 @@ public class PersonCard extends UiPart<Region> {
         if (person instanceof Professor) {
             title.setText("Professor");
         } else if (person instanceof TeachingAssistant) {
-            title.setText("TA");
+            title.setText("Teaching\nAssistant");
         } else {
             title.setText("Student");
         }

--- a/src/main/java/seedu/address/ui/PersonCard.java
+++ b/src/main/java/seedu/address/ui/PersonCard.java
@@ -10,6 +10,8 @@ import javafx.scene.layout.FlowPane;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Region;
 import seedu.address.model.person.Person;
+import seedu.address.model.person.Professor;
+import seedu.address.model.person.TeachingAssistant;
 
 /**
  * An UI component that displays information of a {@code Person}.
@@ -35,6 +37,10 @@ public class PersonCard extends UiPart<Region> {
     @FXML
     private Label id;
     @FXML
+    private Label title;
+    @FXML
+    private Label number;
+    @FXML
     private Label phone;
     @FXML
     private ImageView gender;
@@ -51,7 +57,7 @@ public class PersonCard extends UiPart<Region> {
     public PersonCard(Person person, int displayedIndex) {
         super(FXML);
         this.person = person;
-        id.setText(displayedIndex + ". ");
+        number.setText(displayedIndex + ". ");
         name.setText(person.getName().fullName);
         phone.setText(person.getPhone().value);
         gender.setImage(getGenderImage(person));
@@ -60,6 +66,13 @@ public class PersonCard extends UiPart<Region> {
         person.getTags().stream()
                 .sorted(Comparator.comparing(tag -> tag.tagName))
                 .forEach(tag -> tags.getChildren().add(new Label(tag.tagName)));
+        if (person instanceof Professor) {
+            title.setText("Professor");
+        } else if (person instanceof TeachingAssistant) {
+            title.setText("TA");
+        } else {
+            title.setText("Student");
+        }
     }
 
     private Image getGenderImage(Person person) {

--- a/src/main/resources/view/DarkTheme.css
+++ b/src/main/resources/view/DarkTheme.css
@@ -103,8 +103,18 @@
     -fx-background-color: #3c3e3f;
 }
 
+.list-cell:filled:even #cardPaneLeft {
+    -fx-border-radius: 0 3px 0 0;
+    -fx-border-color: #515658;
+}
+
 .list-cell:filled:odd {
     -fx-background-color: #515658;
+}
+
+.list-cell:filled:odd #cardPaneLeft {
+    -fx-border-radius: 0 3px 0 0;
+    -fx-border-color: #3c3e3f;
 }
 
 .list-cell:filled:selected {
@@ -310,6 +320,11 @@
 #cardPane {
     -fx-background-color: transparent;
     -fx-border-width: 0;
+}
+
+#cardPaneLeft {
+    -fx-border-width: 0 2px 0 0;
+    -fx-border-color: #515658;
 }
 
 #commandTypeLabel {

--- a/src/main/resources/view/PersonListCard.fxml
+++ b/src/main/resources/view/PersonListCard.fxml
@@ -12,17 +12,9 @@
 <?import javafx.scene.layout.VBox?>
 
 <HBox id="cardPane" fx:id="cardPane" xmlns="http://javafx.com/javafx/18" xmlns:fx="http://javafx.com/fxml/1">
-   <VBox fx:id="cardPaneLeft" stylesheets="@DarkTheme.css">
+   <VBox fx:id="cardPaneLeft" maxWidth="-Infinity" prefHeight="105.0" prefWidth="100.0" stylesheets="@DarkTheme.css">
       <children>
-         <HBox prefHeight="0.0" prefWidth="100.0">
-            <children>
-               <Label fx:id="number" text="Label">
-                  <padding>
-                     <Insets left="5.0" top="5.0" />
-                  </padding>
-               </Label>
-            </children>
-         </HBox>
+         <HBox prefHeight="0.0" prefWidth="100.0" />
          <VBox alignment="CENTER">
             <children>
                <Label fx:id="title" text="Label" />

--- a/src/main/resources/view/PersonListCard.fxml
+++ b/src/main/resources/view/PersonListCard.fxml
@@ -12,6 +12,28 @@
 <?import javafx.scene.layout.VBox?>
 
 <HBox id="cardPane" fx:id="cardPane" xmlns="http://javafx.com/javafx/18" xmlns:fx="http://javafx.com/fxml/1">
+   <VBox fx:id="cardPaneLeft" stylesheets="@DarkTheme.css">
+      <children>
+         <HBox prefHeight="0.0" prefWidth="100.0">
+            <children>
+               <Label fx:id="number" text="Label">
+                  <padding>
+                     <Insets left="5.0" top="5.0" />
+                  </padding>
+               </Label>
+            </children>
+         </HBox>
+         <VBox alignment="CENTER">
+            <children>
+               <Label fx:id="title" text="Label" />
+               <HBox prefHeight="30.0" prefWidth="100.0" />
+            </children>
+            <padding>
+               <Insets top="10.0" />
+            </padding>
+         </VBox>
+      </children>
+   </VBox>
   <GridPane HBox.hgrow="ALWAYS">
     <columnConstraints>
       <ColumnConstraints hgrow="SOMETIMES" minWidth="10" prefWidth="150" />
@@ -21,12 +43,12 @@
         <Insets bottom="5" left="15" right="5" top="5" />
       </padding>
       <HBox alignment="CENTER_LEFT" spacing="5">
-        <Label fx:id="id" styleClass="cell_big_label">
+         <Label fx:id="id" styleClass="cell_big_label">
           <minWidth>
             <!-- Ensures that the label text is never truncated -->
             <Region fx:constant="USE_PREF_SIZE" />
           </minWidth>
-        </Label>
+         </Label>
         <Label fx:id="name" styleClass="cell_big_label" text="\$first" />
             <ImageView fx:id="gender" fitHeight="20.0" fitWidth="20.0" pickOnBounds="true" preserveRatio="true" />
       </HBox>


### PR DESCRIPTION
fixes #55 

There is no way for users to differentiate between professor, TA and student contacts.

Let's add a panel to the left of each entry that states the type of contact. This is consistent with the UI structure shown in our UI mockup.

The image below shows how the UI looks after redesign.

![ab3ui](https://user-images.githubusercontent.com/85070805/195992130-0cbb5ad5-51cf-43ed-a90e-fbc5b36fc3f4.png)


Some possible improvements to consider:

-  Colour of the partition line (Does the current colour look off, should it be a uniform colour)
-  Using icons to replace the "professor", "TA" and "Student" titles

Feel free to add any other suggestions that can help improve the look of the UI. 🙂 
