### PR TITLE
Fix sorting by Name and moduleCode

### DIFF
--- a/src/main/java/seedu/address/model/person/ModuleCode.java
+++ b/src/main/java/seedu/address/model/person/ModuleCode.java
@@ -7,7 +7,7 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
  * Represents a Professor/Teaching Assistant's module code in the address book.
  * Guarantees: immutable; is valid as declared in {@link #isValidModuleCode(String)}
  */
-public class ModuleCode {
+public class ModuleCode implements Comparable<ModuleCode> {
 
     public static final String MESSAGE_CONSTRAINTS = "Module code must fulfill the following requirements:\n"
             + "- length between 5 and 7 characters\n"
@@ -63,17 +63,21 @@ public class ModuleCode {
     public int getLevel() {
         return Integer.parseInt(value.replaceAll("\\D", ""));
     }
-
+    public String getPrefix() {
+        return value.replaceAll("\\d", "").toUpperCase();
+    }
     /**
-     * Used as a comparator between two modules. The module code with a higher level higher precedence.
+     * Used as a comparator between two modules. The module code with a higher level higher precedence, tie
+     * breaker is implemented by comparing the prefix of moduleCode
      * @param moduleCode target of comparison
      * @return int
      */
+    @Override
     public int compareTo(ModuleCode moduleCode) {
         return this.getLevel() - moduleCode.getLevel() > 0
                 ? 1
                 : this.getLevel() == moduleCode.getLevel()
-                ? 0
+                ? getPrefix().compareTo(moduleCode.getPrefix())
                 : -1;
     }
     @Override

--- a/src/main/java/seedu/address/model/person/ModuleCode.java
+++ b/src/main/java/seedu/address/model/person/ModuleCode.java
@@ -9,13 +9,18 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
  */
 public class ModuleCode {
 
-    public static final String MESSAGE_CONSTRAINTS = "Module Code can take any values, and it should not be blank";
+    public static final String MESSAGE_CONSTRAINTS = "Module code must fulfill the following requirements:\n"
+            + "- length between 5 and 7 characters\n"
+            + "- begin with either 2 or 3 letters (case insensitive)\n"
+            + "- followed by 4 digits\n"
+            + "- optional of 1 letter behind the 4 digits\n"
+            + "example, ABC1234S";
 
     /*
      * The first character of the module code must not be a whitespace,
      * otherwise " " (a blank string) becomes a valid input.
      */
-    public static final String VALIDATION_REGEX = "[^\\s].*";
+    public static final String VALIDATION_REGEX = "(?=\\S{5,7}$)([a-zA-Z]{2,3})(\\d{4})([a-zA-Z]{0,1})$";
 
     public final String value;
 
@@ -55,7 +60,22 @@ public class ModuleCode {
     public static boolean isValidModuleCodeName(String test) {
         return test.matches(VALIDATION_REGEX);
     }
+    public int getLevel() {
+        return Integer.parseInt(value.replaceAll("\\D", ""));
+    }
 
+    /**
+     * Used as a comparator between two modules. The module code with a higher level higher precedence.
+     * @param moduleCode target of comparison
+     * @return int
+     */
+    public int compareTo(ModuleCode moduleCode) {
+        return this.getLevel() - moduleCode.getLevel() > 0
+                ? 1
+                : this.getLevel() == moduleCode.getLevel()
+                ? 0
+                : -1;
+    }
     @Override
     public int hashCode() {
         return value.hashCode();

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -96,7 +96,7 @@ public abstract class Person {
      * @return int.
      */
     public int compareName(Person person) {
-        return this.name.toString().compareTo(person.name.toString());
+        return this.name.toString().toUpperCase().compareTo(person.name.toString().toUpperCase());
     }
 
     /**
@@ -110,10 +110,10 @@ public abstract class Person {
      * @return int.
      */
     public int compareModuleCode(Person person) {
-        if (person instanceof Student) {
-            return compareName(person);
+        if (person instanceof Student || person instanceof Professor || person instanceof TeachingAssistant) {
+            return -1;
         }
-        return -1;
+        return 0;
     }
 
     /**

--- a/src/main/java/seedu/address/model/person/Professor.java
+++ b/src/main/java/seedu/address/model/person/Professor.java
@@ -130,14 +130,18 @@ public class Professor extends Person {
     @Override
     public int compareModuleCode(Person person) {
         if (person instanceof Professor) {
-            return this.moduleCode.toString()
-                    .compareTo(((Professor) person).moduleCode.toString());
+            return this.moduleCode.toString().toUpperCase()
+                    .compareTo(((Professor) person).getModuleCode().toString().toUpperCase());
         }
         if (person instanceof TeachingAssistant) {
-            return this.moduleCode.toString()
-                    .compareTo(((TeachingAssistant) person).getModuleCode().toString());
+            return this.moduleCode.toString().toUpperCase()
+                    .compareTo(((TeachingAssistant) person).getModuleCode().toString().toUpperCase());
         }
-        return 1;
+        if (person instanceof Student) {
+            return this.moduleCode
+                    .compareTo(((Student) person).getHighestModuleCode());
+        }
+        return this.compareModuleCode(person);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/Student.java
+++ b/src/main/java/seedu/address/model/person/Student.java
@@ -83,13 +83,22 @@ public class Student extends Person {
         }
         return builder.toString();
     }
-
+    public ModuleCode getHighestModuleCode() {
+        return moduleCodes.stream().max(ModuleCode::compareTo).get();
+    }
     @Override
     public int compareModuleCode(Person person) {
+        ModuleCode highest = getHighestModuleCode();
         if (person instanceof Student) {
-            return compareName(person);
+            return highest.compareTo(((Student) person).getHighestModuleCode());
         }
-        return -1;
+        if (person instanceof Professor) {
+            return highest.compareTo(((Professor) person).getModuleCode());
+        }
+        if (person instanceof TeachingAssistant) {
+            return highest.compareTo(((TeachingAssistant) person).getModuleCode());
+        }
+        return this.compareModuleCode(person);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/Student.java
+++ b/src/main/java/seedu/address/model/person/Student.java
@@ -25,6 +25,7 @@ public class Student extends Person {
     public Student(Name name, Phone phone, Email email, Gender gender, Set<Tag> tags,
                    Location location, GithubUsername username, Set<ModuleCode> moduleCodes, Year year) {
         super(name, phone, email, gender, tags, location, username);
+        assert moduleCodes.size() > 0 : "At least 1 moduleCode present";
         this.moduleCodes.addAll(moduleCodes);
         this.year = year;
     }
@@ -84,6 +85,7 @@ public class Student extends Person {
         return builder.toString();
     }
     public ModuleCode getHighestModuleCode() {
+        assert moduleCodes.size() > 0 : "At least 1 moduleCode present";
         return moduleCodes.stream().max(ModuleCode::compareTo).get();
     }
     @Override

--- a/src/main/java/seedu/address/model/person/TeachingAssistant.java
+++ b/src/main/java/seedu/address/model/person/TeachingAssistant.java
@@ -70,14 +70,18 @@ public class TeachingAssistant extends Person {
     @Override
     public int compareModuleCode(Person person) {
         if (person instanceof Professor) {
-            return this.moduleCode.toString()
-                    .compareTo(((Professor) person).getModuleCode().toString());
+            return this.moduleCode.toString().toUpperCase()
+                    .compareTo(((Professor) person).getModuleCode().toString().toUpperCase());
         }
         if (person instanceof TeachingAssistant) {
-            return this.moduleCode.toString()
-                    .compareTo(((TeachingAssistant) person).getModuleCode().toString());
+            return this.moduleCode.toString().toUpperCase()
+                    .compareTo(((TeachingAssistant) person).getModuleCode().toString().toUpperCase());
         }
-        return 1;
+        if (person instanceof Student) {
+            return this.moduleCode
+                    .compareTo(((Student) person).getHighestModuleCode());
+        }
+        return this.compareModuleCode(person);
     }
 
     @Override

--- a/src/main/java/seedu/address/ui/PersonCard.java
+++ b/src/main/java/seedu/address/ui/PersonCard.java
@@ -125,6 +125,7 @@ public class PersonCard extends UiPart<Region> {
         if (person instanceof Student) {
             Student student = (Student) person;
             student.getModuleCodes().stream()
+                    .sorted((m1, m2) -> -1 * m1.compareTo(m2))
                     .forEach(moduleCode -> moduleCodes.getChildren().add(new Label(moduleCode.value)));
             title.setText("Student");
             setYear(student);

--- a/src/test/java/seedu/address/model/person/ModuleCodeTest.java
+++ b/src/test/java/seedu/address/model/person/ModuleCodeTest.java
@@ -1,0 +1,148 @@
+package seedu.address.model.person;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class ModuleCodeTest {
+
+    @Test
+    void isValidModuleCode() {
+        // invalid whitespace
+        assertFalse(ModuleCode.isValidModuleCode(""));
+        assertFalse(ModuleCode.isValidModuleCode("     "));
+        assertFalse(ModuleCode.isValidModuleCode("      "));
+
+        // invalid characters for first 2-3 characters
+        assertFalse(ModuleCode.isValidModuleCode("  1234"));
+        assertFalse(ModuleCode.isValidModuleCode("  1234S"));
+        assertFalse(ModuleCode.isValidModuleCode("   1234"));
+        assertFalse(ModuleCode.isValidModuleCode("   1234S"));
+        assertFalse(ModuleCode.isValidModuleCode("!A1234"));
+        assertFalse(ModuleCode.isValidModuleCode("@A1234"));
+        assertFalse(ModuleCode.isValidModuleCode("#A1234"));
+        assertFalse(ModuleCode.isValidModuleCode("$A1234"));
+        assertFalse(ModuleCode.isValidModuleCode("%A1234"));
+        assertFalse(ModuleCode.isValidModuleCode("^A1234"));
+        assertFalse(ModuleCode.isValidModuleCode("&A1234"));
+        assertFalse(ModuleCode.isValidModuleCode("*A1234"));
+        assertFalse(ModuleCode.isValidModuleCode("(A1234"));
+        assertFalse(ModuleCode.isValidModuleCode(")A1234"));
+        assertFalse(ModuleCode.isValidModuleCode("-A1234"));
+        assertFalse(ModuleCode.isValidModuleCode("_A1234"));
+        assertFalse(ModuleCode.isValidModuleCode("=A1234"));
+        assertFalse(ModuleCode.isValidModuleCode("+A1234"));
+        assertFalse(ModuleCode.isValidModuleCode("[A1234"));
+        assertFalse(ModuleCode.isValidModuleCode("{A1234"));
+        assertFalse(ModuleCode.isValidModuleCode("}A1234"));
+        assertFalse(ModuleCode.isValidModuleCode("]A1234"));
+        assertFalse(ModuleCode.isValidModuleCode("\\A1234"));
+        assertFalse(ModuleCode.isValidModuleCode("|A1234"));
+        assertFalse(ModuleCode.isValidModuleCode(";A1234"));
+        assertFalse(ModuleCode.isValidModuleCode(":A1234"));
+        assertFalse(ModuleCode.isValidModuleCode("'A1234"));
+        assertFalse(ModuleCode.isValidModuleCode("\"A1234"));
+        assertFalse(ModuleCode.isValidModuleCode(",A1234"));
+        assertFalse(ModuleCode.isValidModuleCode("<A1234"));
+        assertFalse(ModuleCode.isValidModuleCode(".A1234"));
+        assertFalse(ModuleCode.isValidModuleCode("?A1234"));
+        assertFalse(ModuleCode.isValidModuleCode(">A1234"));
+        assertFalse(ModuleCode.isValidModuleCode(".A1234"));
+        assertFalse(ModuleCode.isValidModuleCode("/A1234"));
+
+
+
+        // invalid whitespace for 4 digits
+        assertFalse(ModuleCode.isValidModuleCode("AA    "));
+        assertFalse(ModuleCode.isValidModuleCode("AA    S"));
+        assertFalse(ModuleCode.isValidModuleCode("AAA    "));
+        assertFalse(ModuleCode.isValidModuleCode("AAA    S"));
+
+        // invalid characters for optional last character
+        assertFalse(ModuleCode.isValidModuleCode("AA1234 "));
+        assertFalse(ModuleCode.isValidModuleCode("AA1234!"));
+        assertFalse(ModuleCode.isValidModuleCode("AA1234@"));
+        assertFalse(ModuleCode.isValidModuleCode("AA1234#"));
+        assertFalse(ModuleCode.isValidModuleCode("AA1234$"));
+        assertFalse(ModuleCode.isValidModuleCode("AA1234%"));
+        assertFalse(ModuleCode.isValidModuleCode("AA1234^"));
+        assertFalse(ModuleCode.isValidModuleCode("AA1234&"));
+        assertFalse(ModuleCode.isValidModuleCode("AA1234*"));
+        assertFalse(ModuleCode.isValidModuleCode("AA1234("));
+        assertFalse(ModuleCode.isValidModuleCode("AA1234)"));
+        assertFalse(ModuleCode.isValidModuleCode("AA1234-"));
+        assertFalse(ModuleCode.isValidModuleCode("AA1234_"));
+        assertFalse(ModuleCode.isValidModuleCode("AA1234+"));
+        assertFalse(ModuleCode.isValidModuleCode("AA1234="));
+        assertFalse(ModuleCode.isValidModuleCode("AA1234`"));
+        assertFalse(ModuleCode.isValidModuleCode("AA1234~"));
+        assertFalse(ModuleCode.isValidModuleCode("AA1234["));
+        assertFalse(ModuleCode.isValidModuleCode("AA1234{"));
+        assertFalse(ModuleCode.isValidModuleCode("AA1234]"));
+        assertFalse(ModuleCode.isValidModuleCode("AA1234}"));
+        assertFalse(ModuleCode.isValidModuleCode("AA1234\\"));
+        assertFalse(ModuleCode.isValidModuleCode("AA1234|"));
+        assertFalse(ModuleCode.isValidModuleCode("AA1234:"));
+        assertFalse(ModuleCode.isValidModuleCode("AA1234;"));
+        assertFalse(ModuleCode.isValidModuleCode("AA1234'"));
+        assertFalse(ModuleCode.isValidModuleCode("AA1234\""));
+        assertFalse(ModuleCode.isValidModuleCode("AA1234,"));
+        assertFalse(ModuleCode.isValidModuleCode("AA1234<"));
+        assertFalse(ModuleCode.isValidModuleCode("AA1234."));
+        assertFalse(ModuleCode.isValidModuleCode("AA1234>"));
+        assertFalse(ModuleCode.isValidModuleCode("AA1234?"));
+        assertFalse(ModuleCode.isValidModuleCode("AA1234/"));
+
+        // invalid
+        assertFalse(ModuleCode.isValidModuleCode("A1234"));
+        assertFalse(ModuleCode.isValidModuleCode("AA123"));
+        assertFalse(ModuleCode.isValidModuleCode("AA1234 "));
+        assertFalse(ModuleCode.isValidModuleCode("A1234"));
+        assertFalse(ModuleCode.isValidModuleCode("A1234S"));
+        assertFalse(ModuleCode.isValidModuleCode("AAA123"));
+        assertFalse(ModuleCode.isValidModuleCode("AA12345"));
+        assertFalse(ModuleCode.isValidModuleCode("AA12345S"));
+        assertFalse(ModuleCode.isValidModuleCode("AAA12345"));
+        assertFalse(ModuleCode.isValidModuleCode("AAA12345S"));
+
+        // valid
+        assertTrue(ModuleCode.isValidModuleCode("AA1234"));
+        assertTrue(ModuleCode.isValidModuleCode("AA1234S"));
+        assertTrue(ModuleCode.isValidModuleCode("AAA1234"));
+        assertTrue(ModuleCode.isValidModuleCode("AA1234S"));
+        assertTrue(ModuleCode.isValidModuleCode("aa1234"));
+        assertTrue(ModuleCode.isValidModuleCode("aa1234s"));
+    }
+
+    @Test
+    void getLevel() {
+        ModuleCode test = new ModuleCode("AA1234S");
+        int expected = 1234;
+        assertEquals(expected, test.getLevel());
+    }
+
+    @Test
+    void getPrefix() {
+        ModuleCode test = new ModuleCode("AA1234S");
+        String expected = "AAS";
+        assertEquals(expected, test.getPrefix());
+    }
+
+    @Test
+    void compareTo() {
+        ModuleCode lowerLevel = new ModuleCode("AA1000");
+        ModuleCode higherLevel = new ModuleCode("AA2000");
+        ModuleCode lowerPrefix = new ModuleCode("AA0000");
+        ModuleCode higherPrefix = new ModuleCode("BB0000");
+        assertEquals(-1, lowerLevel.compareTo(higherLevel));
+        assertEquals(1, higherLevel.compareTo(lowerLevel));
+        assertEquals(-1, lowerPrefix.compareTo(higherPrefix));
+        assertEquals(1, higherPrefix.compareTo(lowerPrefix));
+        assertEquals(0, lowerLevel.compareTo(lowerLevel));
+        assertEquals(0, higherLevel.compareTo(higherLevel));
+        assertEquals(0, lowerPrefix.compareTo(lowerPrefix));
+        assertEquals(0, higherPrefix.compareTo(higherPrefix));
+    }
+}


### PR DESCRIPTION
**Sorting by Name**
- Sorting by name now considers only alphabetical orders. i.e aaa > BBB instead of lexicographical order whereby BBB has higher precedence than AAA. This fixes #154, #178, #173, #171, #52.

**Sorting by ModuleCode**
 - New ModuleCode regex which requires 3 alphabets followed by 4 numbers followed by an optional alphabet. i.e ABC1234S fixes #142.
 - ModuleCode are now compared purely based on the 4-digit number. i.e ABC1000 and DEF1000 have the same level of precedence. DEF4000 has higher precedence over ABC3000 fixes #168.