### PR TITLE
Enforce stricter file name regex

### DIFF
--- a/src/main/java/seedu/address/commons/core/filename/FileName.java
+++ b/src/main/java/seedu/address/commons/core/filename/FileName.java
@@ -7,12 +7,10 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
  * Represents the file name to be created
  */
 public class FileName {
-    public static final String MESSAGE_CONSTRAINTS = "FileName can only contain the following symbols:\n"
-            + "A-Z\n"
-            + "a-z\n"
-            + "-_.\n"
-            + "0-9";
-    private static final String VALIDATION_REGEX = "^[^*&%\\s]+$";
+    public static final String MESSAGE_CONSTRAINTS = "FileName must follow the following criteria:\n"
+            + "- Can only contain alphanumeric characters, whitespaces, hyphen(-), underscore(_) and full stop(.)\n"
+            + "- Name must be at least 3 characters long and a maximum of 30 characters";
+    private static final String VALIDATION_REGEX = "^[\\w\\-\\s.]{3,30}$";
     private String fileName;
 
     /**

--- a/src/test/java/seedu/address/commons/util/core/filename/FileNameTest.java
+++ b/src/test/java/seedu/address/commons/util/core/filename/FileNameTest.java
@@ -58,6 +58,8 @@ class FileNameTest {
         assertFalse(FileName.isValidFileName(">>>"));
         assertFalse(FileName.isValidFileName("???"));
         assertFalse(FileName.isValidFileName("///"));
+        assertFalse(FileName.isValidFileName("ab"));
+        assertFalse(FileName.isValidFileName("0123456789012345678901234567890"));
 
         // valid fileName
         assertTrue(FileName.isValidFileName("012345678901234567890123456789"));

--- a/src/test/java/seedu/address/commons/util/core/filename/FileNameTest.java
+++ b/src/test/java/seedu/address/commons/util/core/filename/FileNameTest.java
@@ -28,17 +28,51 @@ class FileNameTest {
 
         // invalid fileName
         assertFalse(FileName.isValidFileName("")); // empty string
-        assertFalse(FileName.isValidFileName(" ")); // space only
-        assertFalse(FileName.isValidFileName("  ")); // tab
-        assertFalse(FileName.isValidFileName("&"));
-        assertFalse(FileName.isValidFileName("*"));
-        assertFalse(FileName.isValidFileName("%"));
+        assertFalse(FileName.isValidFileName("&&&"));
+        assertFalse(FileName.isValidFileName("***"));
+        assertFalse(FileName.isValidFileName("%%%"));
+        assertFalse(FileName.isValidFileName("!!!"));
+        assertFalse(FileName.isValidFileName("@@@"));
+        assertFalse(FileName.isValidFileName("###"));
+        assertFalse(FileName.isValidFileName("$$$"));
+        assertFalse(FileName.isValidFileName("^^^"));
+        assertFalse(FileName.isValidFileName("***"));
+        assertFalse(FileName.isValidFileName("~~~"));
+        assertFalse(FileName.isValidFileName("```"));
+        assertFalse(FileName.isValidFileName("((("));
+        assertFalse(FileName.isValidFileName(")))"));
+        assertFalse(FileName.isValidFileName("+++"));
+        assertFalse(FileName.isValidFileName("==="));
+        assertFalse(FileName.isValidFileName("[[["));
+        assertFalse(FileName.isValidFileName("{{{"));
+        assertFalse(FileName.isValidFileName("]]]"));
+        assertFalse(FileName.isValidFileName("}}}"));
+        assertFalse(FileName.isValidFileName("|||"));
+        assertFalse(FileName.isValidFileName("\\\\"));
+        assertFalse(FileName.isValidFileName(":::"));
+        assertFalse(FileName.isValidFileName(";;;"));
+        assertFalse(FileName.isValidFileName("'''"));
+        assertFalse(FileName.isValidFileName("\"\"\""));
+        assertFalse(FileName.isValidFileName("<<<"));
+        assertFalse(FileName.isValidFileName(",,,"));
+        assertFalse(FileName.isValidFileName(">>>"));
+        assertFalse(FileName.isValidFileName("???"));
+        assertFalse(FileName.isValidFileName("///"));
 
         // valid fileName
-        assertTrue(FileName.isValidFileName("filename"));
-        assertTrue(FileName.isValidFileName("FILENAME"));
-        assertTrue(FileName.isValidFileName("0123456789"));
-        assertTrue(FileName.isValidFileName("."));
+        assertTrue(FileName.isValidFileName("012345678901234567890123456789"));
+        assertTrue(FileName.isValidFileName("abcdefghijklmnopqrstuvwxyzabcd"));
+        assertTrue(FileName.isValidFileName("ABCEDFGHIJKLMNOPQRSTUVWXYZABCD"));
+        assertTrue(FileName.isValidFileName("______________________________"));
+        assertTrue(FileName.isValidFileName("------------------------------"));
+        assertTrue(FileName.isValidFileName(".............................."));
+        assertTrue(FileName.isValidFileName("                              "));
+        assertTrue(FileName.isValidFileName("ABC"));
+        assertTrue(FileName.isValidFileName("abc"));
+        assertTrue(FileName.isValidFileName("   "));
+        assertTrue(FileName.isValidFileName("..."));
+        assertTrue(FileName.isValidFileName("---"));
+        assertTrue(FileName.isValidFileName("___"));
     }
 
     @Test


### PR DESCRIPTION
**New file name regex**
- Can only contain alphanumerical characters, whitespace characters, full stop(.), hyphen(-) and lowercase(_)
- Must be within 3 and 30 characters long

This prevents potential bugs when users include \ or / in their file names resulting in creating the export file in a nested directory which might cause confusion. 